### PR TITLE
PR to be able to link in original to clearly display differences in PRs against original

### DIFF
--- a/src/Model/LocaleNotSupported.php
+++ b/src/Model/LocaleNotSupported.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Locastic\ApiPlatformTranslationBundle\Model;
+
+final class LocaleNotSupported extends \RuntimeException
+{
+    public static function unsupported(): self
+    {
+        return new self('No locale was received and the current locale is not supported for translations.');
+    }
+}

--- a/src/Model/TranslatableInterface.php
+++ b/src/Model/TranslatableInterface.php
@@ -16,7 +16,7 @@ interface TranslatableInterface
      */
     public function getTranslations(): Collection;
 
-    public function getTranslation(?string $locale = null): TranslationInterface;
+    public function getTranslation(string $locale = null): ?TranslationInterface;
     public function hasTranslation(TranslationInterface $translation): bool;
 
     public function addTranslation(TranslationInterface $translation): void;

--- a/src/Model/TranslatableTrait.php
+++ b/src/Model/TranslatableTrait.php
@@ -64,7 +64,7 @@ trait TranslatableTrait
         }
 
         // Check and return fallback Translation from Translatable objects' cache or attempt fallback locale match
-        return $this->translationsCache[$this->fallbackLocale] ?? $this->matchTranslation($this->fallbackLocale);
+        return $this->matchTranslation($this->fallbackLocale);
     }
 
     /**

--- a/src/Model/TranslatableTrait.php
+++ b/src/Model/TranslatableTrait.php
@@ -51,7 +51,7 @@ trait TranslatableTrait
             throw LocaleNotSupported::unsupported();
         }
 
-        // Grab translation from Translatable objects' available Translations
+        // Attempt to grab Translation from Translatable object
         $translation = $this->matchTranslation($locale);
         if ($translation instanceof TranslationInterface) {
             return $translation;
@@ -63,7 +63,6 @@ trait TranslatableTrait
             return null;
         }
 
-        // Check and return fallback Translation from Translatable objects' cache or attempt fallback locale match
         return $this->matchTranslation($this->fallbackLocale);
     }
 

--- a/tests/Fixtures/DummyTranslatable.php
+++ b/tests/Fixtures/DummyTranslatable.php
@@ -5,18 +5,10 @@ declare(strict_types=1);
 namespace Locastic\ApiPlatformTranslationBundle\Tests\Fixtures;
 
 use Locastic\ApiPlatformTranslationBundle\Model\AbstractTranslatable;
-use Locastic\ApiPlatformTranslationBundle\Model\TranslationInterface;
 
 /**
  * @package Locastic\ApiPlatformTranslationBundle\Tests\Fixtures
  */
 class DummyTranslatable extends AbstractTranslatable
 {
-    /**
-     * {@inheritdoc}
-     */
-    protected function createTranslation(): TranslationInterface
-    {
-        return new DummyTranslation('en', null);
-    }
 }

--- a/tests/Model/AbstractTranslationTest.php
+++ b/tests/Model/AbstractTranslationTest.php
@@ -43,13 +43,11 @@ class AbstractTranslationTest extends TestCase
     /**
      * @test setTranslatable
      */
-    public function testGetFallbackTranslationWithoutLocaleParameter(): void
+    public function testGetNullWithoutLocaleParameter(): void
     {
         $dummyTranslatable = $this->setTranslatable('es', 'en');
 
-        $dummyTranslationEnglish = $this->setTranslation('en', 'english', $dummyTranslatable);
-
-        $this->assertSame($dummyTranslationEnglish, $dummyTranslatable->getTranslation());
+        $this->assertNull($dummyTranslatable->getTranslation());
     }
 
     /**

--- a/tests/Model/TranslatableTraitTest.php
+++ b/tests/Model/TranslatableTraitTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Locastic\ApiPlatformTranslationBundle\Tests\Model;
 
+use Locastic\ApiPlatformTranslationBundle\Model\LocaleNotSupported;
 use Locastic\ApiPlatformTranslationBundle\Model\TranslatableInterface;
 use Locastic\ApiPlatformTranslationBundle\Tests\Fixtures\DummyTranslatable;
 use Locastic\ApiPlatformTranslationBundle\Tests\Fixtures\DummyTranslation;
@@ -68,6 +69,12 @@ class TranslatableTraitTest extends TestCase
         $this->assertEquals(null, $dummyTranslatable->getTranslation('en')?->getTranslation());
     }
 
+    public function testGetNullWithUnsupportedLocale(): void
+    {
+        $dummyTranslatable = $this->setTranslatable('es', 'en');
+        $this->assertNull($dummyTranslatable->getTranslation('unsupported'));
+    }
+
     /**
      * @test getTranslation
      */
@@ -75,7 +82,7 @@ class TranslatableTraitTest extends TestCase
     {
         $dummyTranslatable = $this->setTranslatable();
 
-        $this->expectException(\RuntimeException::class);
+        $this->expectException(LocaleNotSupported::class);
         $dummyTranslatable->getTranslation();
     }
 

--- a/tests/Model/TranslatableTraitTest.php
+++ b/tests/Model/TranslatableTraitTest.php
@@ -34,7 +34,7 @@ class TranslatableTraitTest extends TestCase
     {
         $dummyTranslatable = $this->setTranslatable('es', 'en');
         $dummyTranslatable->addTranslation($this->setTranslation('en', 'english', $dummyTranslatable));
-        $this->assertEquals('english', $dummyTranslatable->getTranslation('en')->getTranslation());
+        $this->assertEquals('english', $dummyTranslatable->getTranslation('en')?->getTranslation());
     }
 
     /**
@@ -43,7 +43,7 @@ class TranslatableTraitTest extends TestCase
     public function testGetTranslationWithoutFallbackLocale(): void
     {
         $dummyTranslatable = $this->setTranslatable('es', 'en');
-        $this->assertEquals(null, $dummyTranslatable->getTranslation('it')->getTranslation());
+        $this->assertEquals(null, $dummyTranslatable->getTranslation('it')?->getTranslation());
     }
 
     /**
@@ -53,7 +53,7 @@ class TranslatableTraitTest extends TestCase
     {
         $dummyTranslatable = $this->setTranslatable('es', 'en');
         $dummyTranslatable->addTranslation($this->setTranslation('en', 'english', $dummyTranslatable));
-        $this->assertEquals('english', $dummyTranslatable->getTranslation('it')->getTranslation());
+        $this->assertEquals('english', $dummyTranslatable->getTranslation('it')?->getTranslation());
     }
 
     /**
@@ -65,7 +65,7 @@ class TranslatableTraitTest extends TestCase
         $dummyTranslationEnglish = $this->setTranslation('en', 'english', $dummyTranslatable);
 
         $dummyTranslatable->removeTranslation($dummyTranslationEnglish);
-        $this->assertEquals(null, $dummyTranslatable->getTranslation('en')->getTranslation());
+        $this->assertEquals(null, $dummyTranslatable->getTranslation('en')?->getTranslation());
     }
 
     /**
@@ -73,7 +73,7 @@ class TranslatableTraitTest extends TestCase
      */
     public function testGetTranslationWithoutLocales(): void
     {
-        $dummyTranslatable = $this->setTranslatable(null, null);
+        $dummyTranslatable = $this->setTranslatable();
 
         $this->expectException(\RuntimeException::class);
         $dummyTranslatable->getTranslation();
@@ -87,12 +87,7 @@ class TranslatableTraitTest extends TestCase
         return $dummyTranslation;
     }
 
-    /**
-     * @param $currentLocale
-     * @param $fallbackLocale
-     * @return DummyTranslatable
-     */
-    private function setTranslatable($currentLocale, $fallbackLocale): DummyTranslatable
+    private function setTranslatable(string $currentLocale = null, string $fallbackLocale = null): DummyTranslatable
     {
         $dummyTranslatable = new DummyTranslatable();
         $dummyTranslatable->setCurrentLocale($currentLocale);


### PR DESCRIPTION
Changed getTranslation (TranslatableInterface) to allow returning null (no translation). TranslatableTrait now no longer creates a default translation when using getTranslation for a locale that has no Translation. Removed createTranslation from TranslatableTrait. Updated tests to match change (to expect null instead of a new Translation).